### PR TITLE
Offset different backups time/hour so they don't start at once

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -95,7 +95,7 @@ define rsnapshot::server::config (
     command => "${rsnapshot::server::cmd_rsnapshot} -c ${config_file} daily",
     user    => $server_user,
     hour    => $backup_time_hour,
-    minute  => $backup_time_minute
+    minute  => ($backup_time_minute + 50) % 60
   } ->
 
   ## weekly
@@ -103,7 +103,7 @@ define rsnapshot::server::config (
     command => "${rsnapshot::server::cmd_rsnapshot} -c ${config_file} weekly",
     user    => $server_user,
     hour    => ($backup_time_hour + 3) % 24,
-    minute  => $backup_time_minute,
+    minute  => ($backup_time_minute + 50) % 60,
     weekday => $backup_time_weekday
   } ->
 
@@ -111,8 +111,8 @@ define rsnapshot::server::config (
   cron { "rsnapshot-${name}-monthly" :
     command  => "${rsnapshot::server::cmd_rsnapshot} -c ${config_file} monthly",
     user     => $server_user,
-    hour     => ($backup_time_hour + 6) % 24,
-    minute   => $backup_time_minute,
+    hour     => ($backup_time_hour + 7) % 24,
+    minute   => ($backup_time_minute + 50) % 60,
     monthday => $backup_time_dom
   }
 


### PR DESCRIPTION
Offset the backup minute for the daily/weekly/monthy backups. This
prevents the various backups from starting at the same time. Otherwise
it would be a random chance over whether the daily or hourly script ran
on any given day.

Also changed the monthly backup from +6 to +7 from he backup hour. When
using the default settings of running every other hour this will make
sure the monthly backup never starts at the same hour as an hourly one.
