### PR TITLE
Fix compat with newer concat module

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -168,7 +168,7 @@ define rsnapshot::server::config (
     warn  => true
   }
 
-  concat::fragment { "${config_file}_header" :
+  concat::fragment { "${config_file}_rsnapshot_header" :
     target  => $config_file,
     content => template('rsnapshot/config.erb'),
     order   => 01


### PR DESCRIPTION
Newer versions of the concat module have an internal resource that is
already named "${config_file}_header", which conflicts with the one
previously used here.  This would lead to duplicate resource errors.