### PR TITLE
Separate sudo support into two parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ class { 'rsnapshot::client':
   rsync_long_args     => '--delete --numeric-ids --relative --delete-excluded'
   ssh_args            => undef,
   use_sudo            => true,
+  setup_sudo          => true,
   push_ssh_key        => true,
   wrapper_path        => '/opt/rsnapshot_wrappers/',  
 }
@@ -385,6 +386,8 @@ resource to the backup server.
 * `ssh_args`: A list of arguments to pass to ssh.
 * `use_sudo`: If enabled sudo will be used instead of direct root access for
   rsync.
+* `setup_sudo`: If enabled, use the saz/sudo module to configure sudoers for
+  rsnapshot use.
 * `push_ssh_key`: If enabled the server's ssh key will be passed to this client.
 * `wrapper_path`: The path to store the various wrapper script in.
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -62,6 +62,7 @@ class rsnapshot::client (
   $rsync_long_args = $rsnapshot::params::rsync_long_args,
   $ssh_args = $rsnapshot::params::ssh_args,
   $use_sudo = $rsnapshot::params::use_sudo,
+  $setup_sudo = $rsnapshot::params::setup_sudo,
   $push_ssh_key = $rsnapshot::params::push_ssh_key,
   $wrapper_path = $rsnapshot::params::wrapper_path,
   ) inherits rsnapshot::params {
@@ -77,6 +78,7 @@ class rsnapshot::client (
     server_user  => $server_user,
     server       => $server,
     use_sudo     => $use_sudo,
+    setup_sudo   => $setup_sudo,
     push_ssh_key => $push_ssh_key,
     wrapper_path => $wrapper_path_normalized,
   }->

--- a/manifests/client/user.pp
+++ b/manifests/client/user.pp
@@ -3,6 +3,7 @@ class rsnapshot::client::user (
   $server_user = '',
   $server = '',
   $use_sudo = true,
+  $setup_sudo = true,
   $push_ssh_key = true,
   $wrapper_path = '',
   $wrapper_sudo = $rsnapshot::params::wrapper_sudo,
@@ -55,7 +56,7 @@ class rsnapshot::client::user (
   }
 
   # Add sudo config if needed.
-  if $use_sudo {
+  if $use_sudo and $setup_sudo {
     sudo::conf { 'backup_user':
       priority => 99,
       content  => "${client_user} ALL= NOPASSWD: ${wrapper_path}/rsync_sender.sh",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@
 class rsnapshot::params {
 
   $use_sudo = true
+  $setup_sudo = true
   $push_ssh_key = true
 
   $wrapper_rsync_sender = 'rsync_sender.sh'


### PR DESCRIPTION
This change separates sudo support into two parts.  The first part is
configuring the suoders configuration with the saz/sudo module, and the
second part is configuring rsnapshot and the wrapper scripts to use
sudo.  This allows people that don't want to pull in a dependency on
saz/sudo to manually configure sudo and still have this module configure
rsnapshot for sudo.