### PR TITLE
Puppet 4 fixes

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -9,7 +9,8 @@ define rsnapshot::backup (
     host        => $host,
     server      => $::rsnapshot::client::server,
     client_user => $::rsnapshot::client::client_user,
-    options     => $options
+    options     => $options,
+    config_file => undef,
   }
 
 }

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -33,7 +33,7 @@ snapshot_root	<%= @snapshot_root %>/
 #################################
 
 <% @programs.each do |program,directory| -%>
-  <%- if directory.to_s != 'undef' -%>
+  <%- if directory and directory.to_s != 'undef' -%>
 <%= program %>	<%= directory %>
   <%- end -%>
 <% end -%>
@@ -43,7 +43,7 @@ snapshot_root	<%= @snapshot_root %>/
 ###########
 
 <% @options.each do |option,value| -%>
-  <%- if value.to_s != 'undef' -%>
+  <%- if value and value.to_s != 'undef' -%>
 <%= option %>	<%= value %>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
This fixes two issues:

* In puppet 4, undef isn't a string, but is actually a nil value.

* In puppet 4, exported resources must still have all required
  specified, even if they're not used on the host they're being exported
  from.