### PR TITLE
Switch backup server IP to use getaddrinfo

### DIFF
--- a/manifests/client/user.pp
+++ b/manifests/client/user.pp
@@ -38,7 +38,7 @@ class rsnapshot::client::user (
   ## Get Key for remote backup user
   if $push_ssh_key {
     $server_user_exploded = "${server_user}@${server}"
-    $backup_server_ip = inline_template("<% _erbout.concat(Resolv::DNS.open.getaddress('${server}').to_s) %>")
+    $backup_server_ip = inline_template("<%= Addrinfo.getaddrinfo('${server}', 'ssh', nil, :STREAM).first.ip_address %>")
     sshkeys::set_authorized_key { "${server_user_exploded} to ${client_user}":
       local_user  => $client_user,
       remote_user => $server_user_exploded,


### PR DESCRIPTION
By using getaddrinfo() instead of the Resolv module, this can work with
non-DNS based host lookups such as /etc/hosts.