### PR TITLE
Specify SSH key target to fix idempotency issue

### DIFF
--- a/manifests/client/user.pp
+++ b/manifests/client/user.pp
@@ -42,6 +42,7 @@ class rsnapshot::client::user (
     sshkeys::set_authorized_key { "${server_user_exploded} to ${client_user}":
       local_user  => $client_user,
       remote_user => $server_user_exploded,
+      target      => "/home/${client_user}/.ssh/authorized_keys",
       require     => User[$client_user],
       options     => [
         "command=\"${allowed_command}\"",


### PR DESCRIPTION
If the target isn't specified, then sshkeys::set_authorized_key depends
on the homedir fact.  Since the user doesn't exist on the first run,
this fact won't exist and the first puppet run will fail.  Since we have
the home directory hard coded in the user creation anyway, go ahead and
provide that target to the sshkeys class to avoid the idempotency issue.