### PR TITLE
Fix missing tab in main config block

### DIFF
--- a/templates/config.erb
+++ b/templates/config.erb
@@ -101,5 +101,5 @@ exclude	<%= value %>
 ###############################
 
 <% @directories.each do |source_dir| -%>
-backup  <%= @client_user %>@<%= @name %>:<%= source_dir.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>
+backup	<%= @client_user %>@<%= @name %>:<%= source_dir.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>
 <% end -%>


### PR DESCRIPTION
It appears this was accidently changed from a hard tab to two spaces in
commit 3b2d455ab3bb598dcddc11db1a6faeda8dd8dc90.  Without this
directories specified directly as part of the rsnapshot::client config
don't work properly.