### PR TITLE
Make hourly backups optional

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -78,7 +78,7 @@ define rsnapshot::server::config (
   file { $log_file :
     ensure  => present,
     require => File[$log_path]
-  } ->
+  }
 
   # cronjobs
 


### PR DESCRIPTION
There was a stray arrow style dep that worked unless hourly backups
weren't defined.  If hourly deps weren't defined, then an error about an
invalid dep target would be thrown on puppet 4.