### PR TITLE
Make client fqdn configurable for server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ the cronjobs needed to run backups.
 
 ```puppet
 rsnapshot::server::config { 'backupclient.example.com':
+  fqdn                   => $name,
   server                 => $::fqdn,
   config_path            => '/etc/rsnapshot',
   backup_path            => '/backups/rsnapshot',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,5 +1,5 @@
 define rsnapshot::server::config (
-
+  $fqdn = $name,
   $config_path = $rsnapshot::params::server_config_path,
   $backup_path = $rsnapshot::params::server_backup_path,
   $log_path = $rsnapshot::params::server_log_path,

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -101,5 +101,5 @@ exclude	<%= value %>
 ###############################
 
 <% @directories.each do |source_dir| -%>
-backup  <%= @client_user %>@<%= @name %>:<%= source_dir.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>
+backup	<%= @client_user %>@<%= @fqdn %>:<%= source_dir.gsub(/\/$/, '') %>/<%= "\t" %><%= "\t\t." %>
 <% end -%>


### PR DESCRIPTION
When defining a rsnapshot::server::config directly, it's useful to have
a different title than the fqdn.  This is useful if you want to back up
multiple directories on a server, but want to define two different
configs so that you can have different retention periods.