### PR TITLE
Add pre/post client side commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,25 @@ that it is simply discarded. This allows the use of the same mysql profile on
 both production and test machines, with backups only on the production machines
 that are also rsnapshot clients.
 
+### Back Up Pre and Post Actions
+
+When backing up clients hosting services like databases, you may want to run a
+script to snapshot or quiesce the service.  You can do this by specifying pre
+or post wrapper actions.  These will be run on the client immediately before or
+after the rsync operation.
+
+For example, to export the contents of the puppetdb database before running a
+backup of your puppetmaster:
+
+```puppet
+
+class profiles::puppetmaster {
+  rsnapshot::client {
+    cmd_wrapper_preexec  => ['/usr/sbin/puppetdb export -o /root/puppetdb.export --port 8083'],
+    cmd_wrapper_postexec => ['rm -f /root/puppetdb.export'],
+  }
+}
+```
 
 ### Backing Up Machines Outside of Puppet
 
@@ -373,6 +392,8 @@ resource to the backup server.
   to fqdn_rand, giving each host a random weekday for backups.
 * `backup_time_dom`: The day of the month that monthly backups should occur.
   This defaults to fqdn_rand, giving each host a random day of the month.
+* `cmd_wrapper_preexec`: Array of commands to run on client before backups.
+* `cmd_wrapper_postexec`: Array of commands to run on client after backups.
 * `cmd_preexec`: The path to any script that should run before backups.
 * `cmd_postexec`: The path to any script that should run after backups.
 * `cmd_client_rsync`: The path to the client side rsync binary.

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -49,6 +49,8 @@ class rsnapshot::client (
   $backup_time_hour = $rsnapshot::params::backup_time_hour,
   $backup_time_weekday = $rsnapshot::params::backup_time_weekday,
   $backup_time_dom = $rsnapshot::params::backup_time_dom,
+  $cmd_wrapper_preexec = [],
+  $cmd_wrapper_postexec = [],
   $cmd_preexec = $rsnapshot::params::cmd_preexec,
   $cmd_postexec = $rsnapshot::params::cmd_postexec,
   $cmd_client_rsync = $rsnapshot::params::cmd_client_rsync,
@@ -86,6 +88,8 @@ class rsnapshot::client (
   # Add Wrapper Scripts
   class { 'rsnapshot::client::wrappers' :
     wrapper_path     => $wrapper_path_normalized,
+    preexec          => $cmd_wrapper_preexec,
+    postexec         => $cmd_wrapper_postexec,
     cmd_client_rsync => $cmd_client_rsync,
     cmd_client_sudo  => $cmd_client_sudo,
   }

--- a/manifests/client/wrappers.pp
+++ b/manifests/client/wrappers.pp
@@ -1,5 +1,7 @@
 class rsnapshot::client::wrappers (
   $wrapper_path = $rsnapshot::params::wrapper_path,
+  $preexec = [],
+  $postexec = [],
   $cmd_client_rsync = $rsnapshot::params::cmd_client_rsync,
   $cmd_client_sudo = $rsnapshot::params::cmd_client_sudo,
 ) inherits rsnapshot::params {

--- a/templates/rsync_sender.sh.erb
+++ b/templates/rsync_sender.sh.erb
@@ -1,2 +1,14 @@
 #!/bin/bash -e
-exec <%= @cmd_client_rsync %> --server --sender $*
+<% if @preexec.size > 0 -%>
+{ # Redirect output to /dev/null so that the reciever isn't confused by
+  # extraneous output
+  <%= @preexec.join("\n") %>
+} > /dev/null 2>&1
+<% end -%>
+<%= @cmd_client_rsync %> --server --sender $*
+<% if @postexec.size > 0 -%>
+{ # Redirect output to /dev/null so that the reciever isn't confused by
+  # extraneous output
+<%= @postexec.join("\n") %>
+} > /dev/null 2>&1
+<% end -%>


### PR DESCRIPTION
This adds the ability to run one more more commands before or after the
rsync runs on the client side.  This can be used for database snapshots,
dumps, etc.