### PR TITLE
Minor fixes for better error messages and bugfix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,1 @@
+class rsnapshot {}

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -67,7 +67,7 @@ define rsnapshot::server::config (
     $rsync_wrapper_processed = "--rsync-path=\"${wrapper_path_norm}/${wrapper_rsync_ssh}\""
   }
 
-  $rsync_long_args_final = "${ssh_args_processed} ${rsync_long_args} ${rsync_wrapper_processed}".strip
+  $rsync_long_args_final = strip("${ssh_args_processed} ${rsync_long_args} ${rsync_wrapper_processed}")
 
 
   file { $snapshot_root :


### PR DESCRIPTION
Two things, a bugfix and a modulepath fixer.

Without an init.pp here is the error that puppet was returning me:

```
root@server:~# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Resource type rsnapshot::server::config doesn't exist on node server
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

Then after adding the init.pp so puppet can add everything to the module path automatically:

```
root@server:/etc/puppet/modules# puppet agent -t
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Syntax error at '.'; expected '}' at /etc/puppet/modules/rsnapshot/manifests/server/config.pp:70 on node server
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```


As you can see the error message after the init.pp was added is much more helpful.